### PR TITLE
Update NPF text post spec.

### DIFF
--- a/npf-spec.md
+++ b/npf-spec.md
@@ -404,7 +404,7 @@ For example, suppose the following text with two overlapping ranges:
         },
         {
             "start": 9,
-            "end": 20,
+            "end": 34,
             "type": "italic"
         }
     ]


### PR DESCRIPTION
Fixed JSON representing Overlapping ranges of the same type

The formatting in the HTML section shows italic running from character 9 through 34, but the example JSON has the range ending at character 20. The extra italic is not in the example formatting.